### PR TITLE
feat(x/auth): ensure proper destruction of bujmes on ForeverVest.MsgSend

### DIFF
--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -47,7 +47,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		NewValidateMemoDecorator(options.AccountKeeper),
 		NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper),
-		NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		NewSetPubKeyDecorator(options.AccountKeeper, options.BankKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
 		NewValidateSigCountDecorator(options.AccountKeeper),
 		NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
 		NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -5,6 +5,9 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	types2 "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
@@ -46,12 +49,14 @@ type SignatureVerificationGasConsumer = func(meter sdk.GasMeter, sig signing.Sig
 // PubKeys must be set in context for all signers before any other sigverify decorators run
 // CONTRACT: Tx must implement SigVerifiableTx interface
 type SetPubKeyDecorator struct {
-	ak AccountKeeper
+	ak         AccountKeeper
+	bankKeeper types.BankKeeper
 }
 
-func NewSetPubKeyDecorator(ak AccountKeeper) SetPubKeyDecorator {
+func NewSetPubKeyDecorator(ak AccountKeeper, bk types.BankKeeper) SetPubKeyDecorator {
 	return SetPubKeyDecorator{
-		ak: ak,
+		ak:         ak,
+		bankKeeper: bk,
 	}
 }
 
@@ -120,6 +125,47 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 			return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidPubKey, err.Error())
 		}
 		spkd.ak.SetAccount(ctx, acc)
+	}
+
+	messages := tx.GetMsgs()
+
+	for _, msg := range messages {
+		if strings.HasPrefix(sdk.MsgTypeURL(msg), "/cosmos.bank.v1beta1.MsgSend") {
+			msgSend, ok := msg.(*banktypes.MsgSend)
+			if !ok {
+				return ctx, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "invalid message type")
+			}
+
+			// Get MsgSend fromAddress
+			msgSigners := msg.GetSigners()
+			for _, msgSigner := range msgSigners {
+				signerAcc := spkd.ak.GetAccount(ctx, msgSigner)
+
+				if _, ok := signerAcc.(*types2.ForeverVestingAccount); ok {
+
+					// A ForeverVestingAccount is trying to send tokens
+					// We need to look if there is some ujmes in the transaction
+					for _, amount := range msgSend.Amount {
+						if amount.Denom == "ujmes" {
+							// Display amount of ujmes transferred
+							bujmesCoins := sdk.NewCoins(sdk.NewCoin("bujmes", amount.Amount))
+
+							// Move the bujmes from the signer to module
+							err := spkd.bankKeeper.SendCoinsFromAccountToModule(ctx, signerAcc.GetAddress(), govtypes.ModuleName, sdk.NewCoins(sdk.NewCoin("bujmes", amount.Amount)))
+							if err != nil {
+								return ctx, err
+							}
+
+							// Burn the bujmes
+							err = spkd.bankKeeper.BurnCoins(ctx, govtypes.ModuleName, bujmesCoins)
+							if err != nil {
+								return ctx, err
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// Also emit the following events, so that txs can be indexed by these

--- a/x/auth/ante/sigverify.go
+++ b/x/auth/ante/sigverify.go
@@ -151,7 +151,7 @@ func (spkd SetPubKeyDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate b
 							bujmesCoins := sdk.NewCoins(sdk.NewCoin("bujmes", amount.Amount))
 
 							// Move the bujmes from the signer to module
-							err := spkd.bankKeeper.SendCoinsFromAccountToModule(ctx, signerAcc.GetAddress(), govtypes.ModuleName, sdk.NewCoins(sdk.NewCoin("bujmes", amount.Amount)))
+							err := spkd.bankKeeper.SendCoinsFromAccountToModule(ctx, signerAcc.GetAddress(), govtypes.ModuleName, bujmesCoins)
 							if err != nil {
 								return ctx, err
 							}

--- a/x/auth/ante/sigverify_test.go
+++ b/x/auth/ante/sigverify_test.go
@@ -49,7 +49,7 @@ func (suite *AnteTestSuite) TestSetPubKey() {
 	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
 	require.NoError(err)
 
-	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper, suite.app.BankKeeper)
 	antehandler := sdk.ChainAnteDecorators(spkd)
 
 	ctx, err := antehandler(suite.ctx, tx, false)
@@ -144,7 +144,7 @@ func (suite *AnteTestSuite) TestSigVerification() {
 	feeAmount := testdata.NewTestFeeAmount()
 	gasLimit := testdata.NewTestGasLimit()
 
-	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper, suite.app.BankKeeper)
 	svd := ante.NewSigVerificationDecorator(suite.app.AccountKeeper, suite.clientCtx.TxConfig.SignModeHandler())
 	antehandler := sdk.ChainAnteDecorators(spkd, svd)
 
@@ -256,7 +256,7 @@ func (suite *AnteTestSuite) TestSigVerification_ExplicitAmino() {
 	feeAmount := testdata.NewTestFeeAmount()
 	gasLimit := testdata.NewTestGasLimit()
 
-	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper, suite.app.BankKeeper)
 	svd := ante.NewSigVerificationDecorator(suite.app.AccountKeeper, suite.clientCtx.TxConfig.SignModeHandler())
 	antehandler := sdk.ChainAnteDecorators(spkd, svd)
 
@@ -348,7 +348,7 @@ func (suite *AnteTestSuite) runSigDecorators(params types.Params, _ bool, privs 
 	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
 	suite.Require().NoError(err)
 
-	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper)
+	spkd := ante.NewSetPubKeyDecorator(suite.app.AccountKeeper, suite.app.BankKeeper)
 	svgc := ante.NewSigGasConsumeDecorator(suite.app.AccountKeeper, ante.DefaultSigVerificationGasConsumer)
 	svd := ante.NewSigVerificationDecorator(suite.app.AccountKeeper, suite.clientCtx.TxConfig.SignModeHandler())
 	antehandler := sdk.ChainAnteDecorators(spkd, svgc, svd)

--- a/x/auth/types/expected_keepers.go
+++ b/x/auth/types/expected_keepers.go
@@ -7,4 +7,5 @@ import (
 // BankKeeper defines the contract needed for supply related APIs (noalias)
 type BankKeeper interface {
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	BurnCoins(ctx sdk.Context, name string, amt sdk.Coins) error
 }

--- a/x/distribution/keeper/store.go
+++ b/x/distribution/keeper/store.go
@@ -6,7 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
-	gogotypes "github.com/gogo/protobuf/types"
 )
 
 // get the delegator withdraw address, defaulting to the delegator address


### PR DESCRIPTION
## Description

In order to ensure a fair distribution of the voting rights, we require the destruction of the bujmes hold by a ForeverVestingAccount upon transfer of a portion of their unlocked ujmes tokens. 

As a reminder, to ensure fairness upon governance, ForeverVestingAccount are granted with a voting rights token which are unlocked at the same speed than their associated ujmes, in exchange for not being able to stake. 

Therefore, when moved, those bujmes are being destroyed, and the ujmes are being free to use within an Account.